### PR TITLE
Removed closing PHP tags from Intro to PHP

### DIFF
--- a/sites/intro-to-php/adding_topics.step
+++ b/sites/intro-to-php/adding_topics.step
@@ -36,7 +36,6 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			var_dump($_POST);
-			?>
 		PHP
 
 		tip "We are using a `POST` action in our `<form>`, therefore the data will be available in the `$_POST` super global."
@@ -55,7 +54,6 @@ steps do
 				$data = new TopicData();
 				$data->add($_POST);
 			}
-			?>
 		PHP
 
 		message "Submitting the form in your browser will now show this:"

--- a/sites/intro-to-php/configuration.step
+++ b/sites/intro-to-php/configuration.step
@@ -13,7 +13,6 @@ steps do
 			return [
 				'class_path' => realpath('../src')
 			];
-			?>
 		PHP
 	end
 
@@ -50,7 +49,6 @@ steps do
 		<?php
 		require_once '../src/Suggestotron/Config';
 		\\Suggestotron\\Config::setDirectory('../config');
-		?>
 		PHP
 
 		message "Once you have done this, the configuration is available everywhere using:"
@@ -94,7 +92,6 @@ steps do
 			"hostname" => "localhost",
 			"dbname" => "suggestotron",
 		];
-		?>
 		PHP
 	end
 
@@ -119,7 +116,6 @@ steps do
 		return [
 			"title" => "Suggestotron"
 		];
-		?>
 		PHP
 	end
 

--- a/sites/intro-to-php/creating_a_data_class.step
+++ b/sites/intro-to-php/creating_a_data_class.step
@@ -15,7 +15,6 @@ steps do
 			class TopicData {
 				// CLASS CONTENTS GO HERE
 			}
-			?>
 		PHP
 	end
 
@@ -32,7 +31,6 @@ steps do
 					$this->connection = new PDO("mysql:host=localhost;dbname=suggestotron", "root", "root");
 				}
 			}
-			?>
 		PHP
 	end
 
@@ -58,7 +56,6 @@ steps do
 					return $query;
 				}
 			}
-			?>
 		PHP
 
 		tip "Notice how we use the same `SELECT` as in the previous section"

--- a/sites/intro-to-php/deleting_topics.step
+++ b/sites/intro-to-php/deleting_topics.step
@@ -23,7 +23,6 @@ steps do
 				echo "<a href='/delete.php?id=" .$topic['id']. "'>Delete</a>";
 				echo "</p>";
 			}
-			?>
 		PHP
 	end
 
@@ -53,7 +52,6 @@ steps do
 			} else {
 			    echo "An error occurred";
 			}
-			?>
 		PHP
 	end
 

--- a/sites/intro-to-php/editing_topics.step
+++ b/sites/intro-to-php/editing_topics.step
@@ -19,7 +19,6 @@ steps do
 				echo "</p>";
 				echo "<p><a href='/edit.php?id=" .$topic['id']. "'>Edit</a></p>";
 			}
-			?>
 		PHP
 
 		message "The link has been added at the end of our `foreach`. The link has an argument for the `id`."
@@ -91,7 +90,6 @@ steps do
 
 		$data = new TopicData();
 		$topic = $data->getTopic($_GET['id']);
-		?>
 		PHP
 
 		message "At this point, you should be able to see your topic data in the edit form, but if you submit the form nothing will change (yet)."
@@ -135,7 +133,6 @@ steps do
 			echo "Topic not found!";
 			exit;
 		}
-		?>
 		PHP
 
 		message "We use `isset`, and `empty` to check that the variable exists, and has a value"

--- a/sites/intro-to-php/getting_dry.step
+++ b/sites/intro-to-php/getting_dry.step
@@ -45,7 +45,6 @@ steps do
 
 				}
 			}
-			?>
 		PHP
 
 		message "Our router will call these methods, instead of including our `.php` files."
@@ -125,7 +124,6 @@ steps do
 				'title' => 'Suggestotron!',
 				'view_path' => realpath('../views')
 			];
-			?>
 		PHP
 
 		message "You probably already noticed that our calls the `$this->template->render()` are very similar in each action."

--- a/sites/intro-to-php/getting_started.step
+++ b/sites/intro-to-php/getting_started.step
@@ -47,7 +47,6 @@ Select your `suggestotron` directory from the file picker that opens. If everyth
     source_code :php, <<-PHP
       <?php
       phpinfo();
-      ?>
     PHP
   end
 

--- a/sites/intro-to-php/introducing_templates.step
+++ b/sites/intro-to-php/introducing_templates.step
@@ -47,7 +47,6 @@ steps do
 					require $this->page;
 				}
 			}
-			?>
 		PHP
 
 		important "We are not the first people to create a `Template` class, to prevent it from conflicting with other peoples code, we use a namespace to make it unique. In this case, `Suggestotron`."
@@ -155,7 +154,6 @@ steps do
 		    <hr>
 		    <?php
 		}
-		?>
 		PHP
 
 		message "Our topic data, previously assigned to `$topics` is now assigned to `$this->topics` by our template class. The first thing we do in our template file is re-assign it to `$topics` so we can use it easily inside our template."
@@ -175,7 +173,6 @@ steps do
 
 			$template = new \\Suggestotron\\Template("../views/base.phtml");
 			$template->render("../views/index/index.phtml", ['topics' => $topics]);
-			?>
 		PHP
 
 		tip "Notice how we pass the `$topics` variable into the `$template->render()` function. This allows our template to access the data we want it to. It will be accessible as `$this->topics` within the template."
@@ -242,7 +239,6 @@ steps do
 
 			$template = new \\Suggestotron\\Template("../views/base.phtml");
 			$template->render("../views/index/add.phtml");
-			?>
 		PHP
 	end
 
@@ -302,7 +298,6 @@ steps do
 
 			$template = new \\Suggestotron\\Template("../views/base.phtml");
 			$template->render("../views/index/edit.phtml", ['topic' => $topic]);
-			?>
 		PHP
 	end
 
@@ -332,7 +327,6 @@ steps do
 			} else {
 			    echo "An error occurred";
 			}
-			?>
 		PHP
 	end
 end

--- a/sites/intro-to-php/multiple_controllers.step
+++ b/sites/intro-to-php/multiple_controllers.step
@@ -257,7 +257,6 @@ steps do
 				$this->render("/errors/index.phtml", ['message' => "Page not found!" ]);
 			}
 		}
-		?>
 		PHP
 
 		message "This simple controller sends the 404 error header, and then renders the appropriate view, `errors/index` which looks like this:"

--- a/sites/intro-to-php/php_language.step
+++ b/sites/intro-to-php/php_language.step
@@ -226,15 +226,14 @@ pluralize("kiwi");
   end
 
   step do
-    message "When using PHP outside of Psysh, you should put it inside `<?php` and `?>` tags:"
+    message "When using PHP outside of Psysh, you should put a `<?php` tag at the beginning of the file:"
 
     source_code :php, <<-PHP
     <?php
     // Code goes Here
-    ?>
     PHP
 
-    tip "You may notice the two-slashes at the start of the middle line above. This is known as a comment and is ignored by PHP."
+    tip "You may notice the two-slashes at the start of the second line above. This is known as a comment and is ignored by PHP."
   end
 
   step do

--- a/sites/intro-to-php/pretty_urls.step
+++ b/sites/intro-to-php/pretty_urls.step
@@ -100,7 +100,6 @@ steps do
 
 		$router = new \\Suggestotron\\Router();
 		$router->start($route);
-		?>
 		PHP
 	end
 


### PR DESCRIPTION
Removed closing tags from Intro to PHP. I'm a little unsure about the one wording change I made. Suggestions welcome.

https://twitter.com/jakeasmith/status/462031138437877761
https://twitter.com/dshafik/status/461503324270120960
