### PR TITLE
Funky echo statements

### DIFF
--- a/sites/intro-to-php/creating_a_data_class.step
+++ b/sites/intro-to-php/creating_a_data_class.step
@@ -85,7 +85,7 @@ steps do
 
 		source_code :php, <<-PHP
 			foreach ($topics as $topic) {
-				echo "<h3>" .$topic['title']. " (ID: " .$topic['id']. ")</h3>";
+				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
 				echo "<p>";
 				echo nl2br($topic['description']);
 				echo "</p>";

--- a/sites/intro-to-php/deleting_topics.step
+++ b/sites/intro-to-php/deleting_topics.step
@@ -13,15 +13,15 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-                echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
-                echo "<p>";
-                echo nl2br($topic['description']);
-                echo "</p>";
-                echo "<p>"
-                echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
-                echo " | ";
-                echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
-                echo "</p>";
+				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+				echo "<p>";
+				echo nl2br($topic['description']);
+				echo "</p>";
+				echo "<p>"
+				echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
+				echo " | ";
+				echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
+				echo "</p>";
 			}
 			?>
 		PHP

--- a/sites/intro-to-php/deleting_topics.step
+++ b/sites/intro-to-php/deleting_topics.step
@@ -13,15 +13,15 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
                 echo "<p>";
                 echo nl2br($topic['description']);
                 echo "</p>";
                 echo "<p>"
                 echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
-				echo " | ";
-				echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
-				echo "</p>";
+                echo " | ";
+                echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
+                echo "</p>";
 			}
 			?>
 		PHP

--- a/sites/intro-to-php/deleting_topics.step
+++ b/sites/intro-to-php/deleting_topics.step
@@ -13,14 +13,14 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-				echo "<h3>" .$topic['title']. " (ID: " .$topic['id']. ")</h3>";
-				echo "<p>";
-				echo nl2br($topic['description']);
-				echo "</p>";
-				echo "<p>";
-				echo "<a href='/edit.php?id=" .$topic['id']. "'>Edit</a>";
+				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                echo "<p>";
+                echo nl2br($topic['description']);
+                echo "</p>";
+                echo "<p>"
+                echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
 				echo " | ";
-				echo "<a href='/delete.php?id=" .$topic['id']. "'>Delete</a>";
+				echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
 				echo "</p>";
 			}
 			?>

--- a/sites/intro-to-php/editing_topics.step
+++ b/sites/intro-to-php/editing_topics.step
@@ -13,11 +13,11 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
                 echo "<p>";
                 echo nl2br($topic['description']);
                 echo "</p>";
-				echo "<p><a href='/edit.php?id={$topic['id']}'>Edit</a></p>";
+                echo "<p><a href='/edit.php?id={$topic['id']}'>Edit</a></p>";
 			}
 			?>
 		PHP

--- a/sites/intro-to-php/editing_topics.step
+++ b/sites/intro-to-php/editing_topics.step
@@ -13,11 +13,11 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-				echo "<h3>" .$topic['title']. " (ID: " .$topic['id']. ")</h3>";
-				echo "<p>";
-				echo nl2br($topic['description']);
-				echo "</p>";
-				echo "<p><a href='/edit.php?id=" .$topic['id']. "'>Edit</a></p>";
+				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                echo "<p>";
+                echo nl2br($topic['description']);
+                echo "</p>";
+				echo "<p><a href='/edit.php?id={$topic['id']}'>Edit</a></p>";
 			}
 			?>
 		PHP

--- a/sites/intro-to-php/editing_topics.step
+++ b/sites/intro-to-php/editing_topics.step
@@ -13,11 +13,11 @@ steps do
 		source_code :php, <<-PHP
 			<?php
 			foreach ($topics as $topic) {
-                echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
-                echo "<p>";
-                echo nl2br($topic['description']);
-                echo "</p>";
-                echo "<p><a href='/edit.php?id={$topic['id']}'>Edit</a></p>";
+				echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+				echo "<p>";
+				echo nl2br($topic['description']);
+				echo "</p>";
+				echo "<p><a href='/edit.php?id={$topic['id']}'>Edit</a></p>";
 			}
 			?>
 		PHP

--- a/sites/intro-to-php/styling_suggestotron.step
+++ b/sites/intro-to-php/styling_suggestotron.step
@@ -27,15 +27,15 @@ steps do
                 <body>
                     <?php
                     foreach ($topics as $topic) {
-                        echo "<h3>" .$topic['title']. " (ID: " .$topic['id']. ")</h3>";
-                        echo "<p>";
-                        echo nl2br($topic['description']);
-                        echo "</p>";
-                        echo "<p>";
-                        echo "<a href='/edit.php?id=" .$topic['id']. "'>Edit</a>";
-                        echo " | ";
-                        echo "<a href='/delete.php?id=" .$topic['id']. "'>Delete</a>";
-                        echo "</p>";
+                       echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                       echo "<p>";
+                       echo nl2br($topic['description']);
+                       echo "</p>";
+                       echo "<p>
+                       echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
+                       echo " | ";
+                       echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
+                       echo "</p>";
                     }
                     ?>
                 </body>
@@ -72,9 +72,9 @@ steps do
         message "For example, by adding a simple class to our Edit and Delete links, we can make them look like buttons:"
 
         source_code :php, <<-PHP
-            echo "<a href='/edit.php?id=" .$topic['id']. "' class='btn btn-primary'>Edit</a>";
+            echo "<a href='/edit.php?id={$topic['id']}' class='btn btn-primary'>Edit</a>";
             echo " ";
-            echo "<a href='/delete.php?id=" .$topic['id']. "' class='btn btn-danger'>Delete</a>";
+            echo "<a href='/delete.php?id={$topic['id']}' class='btn btn-danger'>Delete</a>";
         PHP
     end
 

--- a/sites/intro-to-php/styling_suggestotron.step
+++ b/sites/intro-to-php/styling_suggestotron.step
@@ -27,15 +27,15 @@ steps do
                 <body>
                     <?php
                     foreach ($topics as $topic) {
-                       echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
-                       echo "<p>";
-                       echo nl2br($topic['description']);
-                       echo "</p>";
-                       echo "<p>
-                       echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
-                       echo " | ";
-                       echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
-                       echo "</p>";
+                        echo "<h3>{$topic['title']} (ID: {$topic['id']})</h3>";
+                        echo "<p>";
+                        echo nl2br($topic['description']);
+                        echo "</p>";
+                        echo "<p>
+                        echo "<a href='/edit.php?id={$topic['id']}'>Edit</a>";
+                        echo " | ";
+                        echo "<a href='/delete.php?id={$topic['id']}'>Delete</a>";
+                        echo "</p>";
                     }
                     ?>
                 </body>


### PR DESCRIPTION
Fixes issue #27.

Changed confusing multiple quote echo statements in the style of:
echo "<p>" . $fruits['id'] . " Another thing.</p>";

With a less confusing double-quote echo statement in the style of:
echo "<p>{$fruits['id']} Another thing.</p>";
