### PR TITLE
reformatted the group around the debugger gem; got rid of the error mess...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,6 @@ group :development do
   gem 'rb-fsevent', :platform => :ruby
 end
 
-gem 'debugger', group: [:development, :test]
+group :development, :test do
+  gem 'debugger'
+end


### PR DESCRIPTION
...age

Fixes Issue #43 
This pull request changes the syntax of the group surrounding debugger gem,which gets rid of the error message.
